### PR TITLE
Bump html2canvas to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartwerk-editor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "React/Redux chart template editor.",
   "main": "src/js/app.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "gulp": "^3.9.1",
     "gulp-json-srv": "^1.0.1",
     "gulp-nunjucks-render": "^2.0.0",
-    "html2canvas": "^1.0.0-alpha.6",
+    "html2canvas": "^1.0.0-alpha.10",
     "imports-loader": "^0.7.1",
     "isomorphic-fetch": "^2.2.1",
     "jquery": "^3.2.1",


### PR DESCRIPTION
We've noticed that our data tables' borders aren't showing up in screenshots.

I've included a sample Chartwerk-generated screenshot. There should be a thick rule under the header row, and 1px rules under each subsequent row, but none of them currently show up.

![chartwerk 6](https://user-images.githubusercontent.com/653174/38053011-8e505828-3298-11e8-860f-28f08917fc4f.jpg)

I think this may be something that has been resolved by newer versions of [`html2canvas`](https://github.com/niklasvh/html2canvas) (see [this issue](https://github.com/niklasvh/html2canvas/issues/1317), which claims to have been fixed by `v1.0.0-alpha.7`).

We're currently on `v1.0.0-alpha.6`, and the latest version (which has been out for at least a month is `1.0.0-alpha.10`).

Would we be able to bump to `...alpha.10`, as I've done here?